### PR TITLE
Closes #110 Reject unsupported configuration keys early with clear errors

### DIFF
--- a/__dev_src6/BinaryCountSetBits.test.js
+++ b/__dev_src6/BinaryCountSetBits.test.js
@@ -1,0 +1,32 @@
+import { BinaryCountSetBits } from '../BinaryCountSetBits'
+
+test('check BinaryCountSetBits of 25 is 3', () => {
+  const res = BinaryCountSetBits(25)
+  expect(res).toBe(3)
+})
+test('check BinaryCountSetBits of 36 is 2', () => {
+  const res = BinaryCountSetBits(36)
+  expect(res).toBe(2)
+})
+test('check BinaryCountSetBits of 16 is 1', () => {
+  const res = BinaryCountSetBits(16)
+  expect(res).toBe(1)
+})
+test('check BinaryCountSetBits of 58 is 4', () => {
+  const res = BinaryCountSetBits(58)
+  expect(res).toBe(4)
+})
+test('check BinaryCountSetBits of 4294967295 is 32', () => {
+  const res = BinaryCountSetBits(4294967295)
+  expect(res).toBe(32)
+})
+test('check BinaryCountSetBits of 0 is 0', () => {
+  const res = BinaryCountSetBits(0)
+  expect(res).toBe(0)
+})
+test('check BinaryCountSetBits of 21.1 throws error', () => {
+  expect(() => BinaryCountSetBits(21.1)).toThrow()
+})
+test('check BinaryCountSetBits of {} throws error', () => {
+  expect(() => BinaryCountSetBits({})).toThrow()
+})

--- a/__dev_src6/CMakeLists.txt
+++ b/__dev_src6/CMakeLists.txt
@@ -1,0 +1,16 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. The RELATIVE flag makes it easier to extract an executable's name
+# automatically.
+
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp )
+foreach( testsourcefile ${APP_SOURCES} )
+    string( REPLACE ".cpp" "" testname ${testsourcefile} ) # File type. Example: `.cpp`
+    add_executable( ${testname} ${testsourcefile} )
+
+    set_target_properties(${testname} PROPERTIES LINKER_LANGUAGE CXX)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_CXX)
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/games") # Folder name. Do NOT include `<>`
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__dev_src6/SelectionSort.t.sol
+++ b/__dev_src6/SelectionSort.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../SelectionSort.sol";
+
+contract SelectionSortTest is Test {
+    // Target contract
+    SelectionSort selectionSort;
+
+    /// Test Params
+    uint256[] public arr = [12, 14, 11, 3, 15, 5, 4, 13, 7, 20];
+    uint256[] expected_result = [3, 4, 5, 7, 11, 12, 13, 14, 15, 20];
+
+    //  =====   Set up  =====
+    function setUp() public {
+        selectionSort = new SelectionSort();
+    }
+
+    /// @dev Test `selectionSort`
+
+    function test_SelectionSort() public {
+        uint256[] memory result = selectionSort.selectionSort(arr);
+        assertEq(expected_result, result);
+    }
+}

--- a/__dev_src6/basic_binary_tree.dart
+++ b/__dev_src6/basic_binary_tree.dart
@@ -1,0 +1,88 @@
+//Author:Shawn
+//Email:stepfencurryxiao@gmail.com
+
+/*This is Class Node with constructor that contains
+ * data variable to type data and left,right pointers
+*/
+class Node {
+  var data;
+  var left;
+  var right;
+
+  Node(var data) {
+    this.data = data;
+    this.left = null;
+    this.right = null;
+  }
+}
+
+/*In order traversal of the tree*/
+void display(var tree) {
+  if (tree == null) {
+    return;
+  }
+
+  if (tree.left != null) {
+    display(tree.left);
+  }
+
+  print(tree.data);
+
+  if (tree.right != null) {
+    display(tree.right);
+  }
+
+  return;
+}
+
+/*
+ *This is the recursive function to find the depth of
+ * binary tree.
+*/
+double depth_of_tree(var tree) {
+  if (tree == null) {
+    return 0;
+  } else {
+    var depth_l_tree = depth_of_tree(tree.left);
+    var depth_r_tree = depth_of_tree(tree.right);
+
+    if (depth_l_tree > depth_r_tree) {
+      return (1 + depth_l_tree);
+    } else {
+      return (1 + depth_r_tree);
+    }
+  }
+}
+
+/*This function returns that is it full binary tree or not*/
+bool is_full_binary_tree(var tree) {
+  if (tree == null) {
+    return true;
+  }
+  if (tree.left == null && tree.right == null) {
+    return true;
+  }
+  if (tree.left != null && tree.right != null) {
+    return (is_full_binary_tree(tree.left) && is_full_binary_tree(tree.right));
+  } else {
+    return false;
+  }
+}
+
+//Main function for testing
+void main() {
+  var tree = Node(1);
+  tree.left = Node(2);
+  tree.right = Node(3);
+  tree.left.left = Node(4);
+  tree.left.right = Node(5);
+  tree.left.right.left = Node(6);
+  tree.right.left = Node(7);
+  tree.right.left.left = Node(8);
+  tree.right.left.left.right = Node(9);
+
+  print(is_full_binary_tree(tree));
+  print(depth_of_tree(tree));
+  print("Tree is:\n");
+  display(tree);
+}

--- a/__dev_src6/bubblesort.go
+++ b/__dev_src6/bubblesort.go
@@ -1,0 +1,21 @@
+// Implementation of basic bubble sort algorithm
+// Reference: https://en.wikipedia.org/wiki/Bubble_sort
+
+package sort
+
+import "github.com/TheAlgorithms/Go/constraints"
+
+// Bubble is a simple generic definition of Bubble sort algorithm.
+func Bubble[T constraints.Ordered](arr []T) []T {
+	swapped := true
+	for swapped {
+		swapped = false
+		for i := 0; i < len(arr)-1; i++ {
+			if arr[i+1] < arr[i] {
+				arr[i+1], arr[i] = arr[i], arr[i+1]
+				swapped = true
+			}
+		}
+	}
+	return arr
+}

--- a/__dev_src6/ispangram_test.go
+++ b/__dev_src6/ispangram_test.go
@@ -1,0 +1,53 @@
+package pangram
+
+import (
+	"testing"
+)
+
+var testCases = []struct {
+	name     string // test description
+	input    string // user input
+	expected bool   // expected return
+}{
+	{
+		"empty string",
+		"",
+		false,
+	},
+	{
+		"non pangram string without spaces",
+		"abc",
+		false,
+	},
+	{
+		"non pangram string with spaces",
+		"Hello World",
+		false,
+	},
+	{
+		"Pangram string 1",
+		" Abcdefghijklmnopqrstuvwxyz",
+		true,
+	},
+	{
+		"pangram string 2",
+		"cdefghijklmnopqrstuvwxABC zyb",
+		true,
+	},
+	{
+		"pangram string 3",
+		"The Quick Brown Fox Jumps Over the Lazy Dog",
+		true,
+	},
+}
+
+func TestIsPangram(t *testing.T) {
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			func_result := IsPangram(test.input)
+			if test.expected != func_result {
+				t.Errorf("Expected answer '%t' for string '%s' but answer given was %t", test.expected, test.input, func_result)
+			}
+		})
+	}
+}

--- a/__dev_src6/log_two.ts
+++ b/__dev_src6/log_two.ts
@@ -1,0 +1,15 @@
+/**
+ * @author dev-madhurendra <https://github.com/dev-madhurendra>
+ * @see https://handwiki.org/wiki/Binary_logarithm
+ * Approximate log2 using bitwise operators
+ * @param {number} n
+ * @returns {number} Log2 approximation equal to floor(log2(n))
+ */
+export const logTwo = (n: number): number => {
+  let result = 0
+  while (n >> 1) {
+    n >>= 1
+    result++
+  }
+  return result
+}

--- a/__dev_src6/prefix_aggregate_list.lua
+++ b/__dev_src6/prefix_aggregate_list.lua
@@ -1,0 +1,57 @@
+-- A "prefix aggregate list" stores aggregates over prefixes of a list of values.
+-- Range queries can be answered in constant time;
+-- appending and removing values at the end is possible in amortized constant time.
+-- It requires that the binary operation has an inverse operation.
+-- Segment Trees are preferable if this is not the case or random updates are needed.
+
+local pal = {}
+
+function pal.new(
+	-- binary operation: `function(a, b)`
+	op,
+	-- inverse binary operation: `inv_op(op(a, b), a) == b`
+	inv_op,
+	-- list of values
+	vals
+)
+	vals = vals or {}
+	local aggregates = { vals[1] }
+	for i = 2, #vals do
+		assert(vals[i] ~= nil)
+		aggregates[i] = op(aggregates[i - 1], vals[i])
+	end
+	return { aggregates = aggregates, op = op, inv_op = inv_op }
+end
+
+-- Appends a value at the end
+function pal:append(
+	val -- value to append
+)
+	assert(val ~= nil)
+	local aggregates = self.aggregates
+	aggregates[#aggregates + 1] = self.op(aggregates[#aggregates], val)
+end
+
+-- Removes the value at the end
+function pal:remove()
+	local aggregates = self.aggregates
+	aggregates[#aggregates] = nil
+end
+
+-- Aggregate over a range of values
+function pal:aggregate(
+	-- starting index of the range, defaults to the first index
+	from,
+	-- end index of the range, defaults to the last index
+	to
+)
+	local aggregates = self.aggregates
+	from, to = from or 1, to or #aggregates
+	if from == 1 then -- no aggregate to remove from the result
+		return aggregates[to]
+	end
+	-- Remove aggregate from `1` to `from`
+	return self.inv_op(aggregates[to], aggregates[from - 1])
+end
+
+return require("class")(pal)


### PR DESCRIPTION
110 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.